### PR TITLE
@link tag support

### DIFF
--- a/helpers/link-to.js
+++ b/helpers/link-to.js
@@ -1,4 +1,5 @@
 var a = require("array-tools"),
+    url = require('url'),
     util = require("util");
 
 module.exports = function(handlebars){
@@ -20,13 +21,26 @@ module.exports = function(handlebars){
             if (builtInType){
                 return "`" + (fullName || longname) + "`";
             } else {
-                var linked = a.findWhere(options.data.root, { longname: longname });
+                var linked = a.findWhere(options.data.root, { longname: longname }),
+                    mask;
                 if (linked){
                     linked.isConstructor = false;
                     if (fullName) fullName = fullName.replace(/</g, "&lt;").replace(/>/g, "&gt;");
                     var linkText = fullName ? fullName.replace(longname, linked.name) : linked.name;
-                    return util.format("[%s](#%s)", linkText, handlebars.helpers.anchorName.call(linked, options));
+                    mask = options.monospace ? "`[%s](#%s)`" : "[%s](#%s)";
+                    return util.format(mask, linkText, handlebars.helpers.anchorName.call(linked, options));
                 } else {
+                    if (url.parse(fullName || longname).protocol) {
+                        switch (options.style) {
+                            case 'code':
+                                mask = '`[%s](%s)`';
+                                break;
+                            case 'plain':
+                            default:
+                                mask = '[%s](%s)';
+                        }
+                        return util.format(mask, options.caption || fullName || longname, fullName || longname);
+                    }
                     return "`" + (fullName || longname) + "`";
                 }
             }

--- a/helpers/linkify.js
+++ b/helpers/linkify.js
@@ -1,0 +1,31 @@
+var a = require("array-tools"),
+    o = require('object-tools'),
+    url = require('url');
+
+module.exports = function (handlebars) {
+    handlebars.registerHelper("linkify", function (text, options) {
+        var linksRx = /(\[.+\])?\{@link\s+.*?\}/gmi,
+            targetRx = /(?:\[(.+)\])?{@link(code|plain)?\s+?(?:(?:([^|]+)\|(.*))|(.+?)(?:\s+(.*))?)\}/mi,
+            linkTags,
+            links = {};
+        if (!(linkTags = text.match(linksRx))) {
+            return text;
+        }
+        linkTags.forEach(function (linkTag) {
+            var parsedLink = linkTag.match(targetRx);
+            var caption = parsedLink[1] || parsedLink[4] || parsedLink[6];
+            var style = !!parsedLink[2];
+            var target = parsedLink[3] || parsedLink[5];
+            links[parsedLink[0]] = handlebars.helpers.linkTo.call(this, target, o.extend({}, options, {
+                style: style,
+                caption: caption
+            }));
+        });
+        for (var link in links) {
+            if (links.hasOwnProperty(link)) {
+                text = text.replace(link, links[link]);
+            }
+        }
+        return text;
+    });
+};

--- a/partials/field/description.hbs
+++ b/partials/field/description.hbs
@@ -1,3 +1,3 @@
-{{#if description}}{{{description}}}
+{{#if description}}{{{linkify description}}}
 
 {{/if}}

--- a/test/fixture/class.json
+++ b/test/fixture/class.json
@@ -31,7 +31,7 @@
     "codeName": "FileSet"
   },
   {
-    "description": "the prototype instance property",
+    "description": "the prototype {@link http://zombo.com|instance} property",
     "name": "files",
     "longname": "module:file-set#files",
     "kind": "member",

--- a/test/test.js
+++ b/test/test.js
@@ -34,6 +34,16 @@ test("cli check", function(t){
     });
 });
 
+test("linkify", function (t) {
+    t.plan(1);
+
+    fs.createReadStream("test/fixture/class.json").pipe(dmd()).on("readable", function () {
+        var md = this.read();
+        t.ok(md.toString().indexOf('[instance](http://zombo.com)') >= 0);
+    });
+
+});
+
 test("partials");
 test("headers");
 test("plugins");


### PR DESCRIPTION
should support:

```
{@link someSymbol}
{@link http://some.url.com}
[caption here]{@link someSymbol}
[caption here]{@link http://some.url.com}
{@link someSymbol|caption here}
{@link http://some.url.com|caption here}
{@link http://some.url.com Caption Here (after the first space)}
{@link someSymbol Caption Here (after the first space)}
```

and `@linkplain` and `@linkcode` tags.
- added `linkify` Handlebars helper
- used this in the `description.hbs` template
- parse all `{@link}` tags within `@description` tags, then handoff to `linkTo` helper.  
- modified `linkTo` to support URLs and styling (if present)
- need to look in other tags too, but this is a good start.
- added test
