### PR TITLE
Add support to display/style @example captions

### DIFF
--- a/helpers/helpers.js
+++ b/helpers/helpers.js
@@ -305,18 +305,30 @@ function params(options){
 function examples(options){
     if (this.examples){
         return this.examples.reduce(function(prev, example){
+            var lines = example.split('\n');
+            var matches = lines[0].match(/\s*<caption>(.*?)<\/caption>\s*/);
+            var caption;
+
+            if (matches) {
+                caption = matches[1];
+                example = lines.slice(1).join('\n');
+            }
+
             var exampleLangOptions = ddata.option("example-lang", options);
-            var matches = example.match(/@lang\s+(\w+)\s*/);
+            matches = example.match(/@lang\s+(\w+)\s*/);
+
             if (matches){
                 var exampleLangSubtag = matches[1];
                 example = example.replace(matches[0], "");
             }
+
             var exampleLang = exampleLangSubtag || exampleLangOptions;
 
             if (!(/```/.test(example) || exampleLang === "off" )){
                 example = util.format("```%s\n%s\n```", exampleLang, example);
             }
-            return prev + options.fn(example);
+
+            return prev + options.fn({caption: caption, example: example});
         }, "");
     }
 }

--- a/partials/all-docs/docs/body/examples.hbs
+++ b/partials/all-docs/docs/body/examples.hbs
@@ -1,4 +1,4 @@
 {{#examples}}
-{{_ "md.bold"}}{{_ "tag.Example"}}{{_ "md.bold"}}  
-{{{inlineLinks this}}}
+{{_ "md.bold"}}{{_ "tag.Example"}}{{_ "md.bold"}}{{#if caption}} {{_ "md.italic"}}({{caption}}){{_ "md.italic"}}{{/if}}
+{{{inlineLinks example}}}
 {{/examples}}


### PR DESCRIPTION
This commit makes it so that whenever you have captions for your `@example` tag, they get displayed and styled as part of the `Example` header instead of being displayed within the example itself.  This is related to [jsdoc2md/jsdoc-to-markdown/issues/33](https://github.com/jsdoc2md/jsdoc-to-markdown/issues/33).  I did not see a good way to test this but I will gladly add tests if you can help me figure out how.  That being said, I did drop this patched version of dmd into my project and I saw that non-captioned examples were unchanged and captioned examples were updated to use the new display/style.