### PR TITLE
Fix moduleSearch() to be able to resolve paths outside of node_modules

### DIFF
--- a/lib/dmd.js
+++ b/lib/dmd.js
@@ -198,6 +198,12 @@ function moduleSearch (moduleName) {
     var modulePath = path.join(basedir, 'node_modules', moduleName)
     if (fs.existsSync(modulePath)) {
       return modulePath
+    } else {
+      /* if the module cannot be found after multiple directory tests, use the normalized, unfiltered moduleName */
+      var unfilteredPath = path.normalize(moduleName);
+      if (fs.existsSync(unfilteredPath)) {
+        return unfilteredPath;
+      }
     }
   }
 }


### PR DESCRIPTION
When using dmd module in other projects (e.g.: gulp-jsdoc-to-markdown) and/or nested within directories, the moduleSearch() function cannot properly resolve module paths for custom plugins, when the path of plugins do not contain **node_modules** in their directory structure. This minor modification fixes this issue.

**Fixes #32**