### PR TITLE
handlebars < 4 has security vulnerability; updating to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "common-sequence": "^1.0.2",
     "core-js": "^2.4.1",
     "file-set": "^1.1.1",
-    "handlebars": "3.0.3",
+    "handlebars": "4.0.6",
     "marked": "^0.3.6",
     "object-get": "^2.1.0",
     "reduce-flatten": "^1.0.1",


### PR DESCRIPTION
- handlebars 3.0.3 has known vulnerabilities (both on its own and in its dependencies)
- updating to 4 seems to be painless (all tests pass; jsdoc-to-markdown generates valid output)