### PR TITLE
Avoid "static class" / "static interface" / "static const"

### DIFF
--- a/partials/all-docs/docs/body/scope.hbs
+++ b/partials/all-docs/docs/body/scope.hbs
@@ -2,7 +2,7 @@
 **Kind**: {{#if (equal kind "event") ~}}
 event emitted{{#if memberof}} by {{>link to=memberof}}{{/if}}  
 {{else~}}
-{{scope}} {{#if virtual}}abstract {{/if}}{{kindInThisContext}}{{#if memberof}} of {{>link to=memberof}}{{/if}}  
+{{#unless (equal scope "static") ~}}{{scope}} {{/unless}}{{#if virtual}}abstract {{/if}}{{kindInThisContext}}{{#if memberof}} of {{>link to=memberof}}{{/if}}  
 {{/if~}}
 {{else~}}
 {{#if isExported}}**Kind**: Exported {{kind}}  

--- a/partials/all-docs/docs/body/scope.hbs
+++ b/partials/all-docs/docs/body/scope.hbs
@@ -2,7 +2,7 @@
 **Kind**: {{#if (equal kind "event") ~}}
 event emitted{{#if memberof}} by {{>link to=memberof}}{{/if}}  
 {{else~}}
-{{#unless (equal scope "static") ~}}{{scope}} {{/unless}}{{#if virtual}}abstract {{/if}}{{kindInThisContext}}{{#if memberof}} of {{>link to=memberof}}{{/if}}  
+{{#unless (equal kind "interface") ~}}{{scope}} {{/unless}}{{#if virtual}}abstract {{/if}}{{kindInThisContext}}{{#if memberof}} of {{>link to=memberof}}{{/if}}  
 {{/if~}}
 {{else~}}
 {{#if isExported}}**Kind**: Exported {{kind}}  


### PR DESCRIPTION
`static interface` or `static class` just add info noise — but interface cannot be static. Class also.

`static const` will be also rendered as `const` But currently `instance` is always specified for non-static, so, it is ok.