### PR TITLE
Move the <code> tags to the inside of the link

### DIFF
--- a/partials/shared/value/link.hbs
+++ b/partials/shared/value/link.hbs
@@ -1,7 +1,7 @@
 {{! usage: link to="namepath" html=true/false caption="optional caption"~}}
 
-<code>
 {{~#if html~}}
+<code>
 
 {{#link to~}}
 {{#if url~}}
@@ -11,15 +11,15 @@
 {{/if~}}
 {{/link~}}
 
+</code>
 {{else~}}
 
 {{#link to~}}
 {{#if url~}}
-[{{#if ../../caption}}{{escape ../../../caption}}{{else}}{{escape name}}{{/if}}]({{{url}}})
+[<code>{{#if ../../caption}}{{escape ../../../caption}}{{else}}{{escape name}}{{/if}}</code>]({{{url}}})
 {{~else~}}
-{{#if ../../caption}}{{escape ../../../caption}}{{else}}{{escape name}}{{/if~}}
+<code>{{#if ../../caption}}{{escape ../../../caption}}{{else}}{{escape name}}{{/if~}}</code>
 {{/if~}}
 {{/link~}}
 
 {{/if~}}
-</code>

--- a/partials/shared/value/link.hbs
+++ b/partials/shared/value/link.hbs
@@ -3,7 +3,7 @@
 {{~#if html~}}
 <code>
 
-{{#link to~}}
+{{~#link to~}}
 {{#if url~}}
 <a href="{{{url}}}">{{#if ../../caption}}{{../../../caption}}{{else}}{{name}}{{/if}}</a>
 {{~else~}}
@@ -12,14 +12,14 @@
 {{/link~}}
 
 </code>
-{{else~}}
+{{~else~}}
 
 {{#link to~}}
 {{#if url~}}
 [<code>{{#if ../../caption}}{{escape ../../../caption}}{{else}}{{escape name}}{{/if}}</code>]({{{url}}})
 {{~else~}}
 <code>{{#if ../../caption}}{{escape ../../../caption}}{{else}}{{escape name}}{{/if~}}</code>
-{{/if~}}
+{{~/if~}}
 {{/link~}}
 
 {{/if~}}


### PR DESCRIPTION
This fixes an issue where Kramdown (GitHub Pages’ default Markdown processor) renders links as code:

    <code>[Server](#Server)</code>

Instead of as links:

    <code><a href="#Server">Server</a></code>