### PR TITLE
use cache-point@0.4.0 instead of ^0.4.0 to avoid errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "array-back": "^1.0.4",
-    "cache-point": "^0.4.0",
+    "cache-point": "0.4.0",
     "common-sequence": "^1.0.2",
     "file-set": "^1.1.1",
     "handlebars": "3.0.3",


### PR DESCRIPTION
Fixes #49 