### PR TITLE
Add Interfaces to global index

### DIFF
--- a/partials/main-index/global-index/global-index.hbs
+++ b/partials/main-index/global-index/global-index.hbs
@@ -7,3 +7,4 @@
 {{>global-index-kinds kind="event" title="Events" ~}}
 {{>global-index-kinds kind="typedef" title="Typedefs" ~}}
 {{>global-index-kinds kind="external" title="External" ~}}
+{{>global-index-kinds kind="interface" title="Interfaces" ~}}


### PR DESCRIPTION
Interfaces were not included in the global index when documented using @interface. This change adds them to an "Interfaces" index.