### PR TITLE
Update `handlebars` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "cache-point": "^0.4.0",
     "common-sequence": "^1.0.2",
     "file-set": "^1.1.1",
-    "handlebars": "3.0.3",
+    "handlebars": "^4.0.11",
     "marked": "^0.3.6",
     "object-get": "^2.1.0",
     "reduce-flatten": "^1.0.1",


### PR DESCRIPTION
Resolves [CVE-2015-8861](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-8861).

`handlebars` depends on `uglify-js`. Updating `handlebars` to version `4.x` bumps `uglify-js` from version `2.3.6` to version `2.8.29`. So, this PR also resolves [CVE-2015-8858](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-8858) and [CVE-2015-8857](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-8857).