### PR TITLE
Fix: Both caption and lang in example

### DIFF
--- a/helpers/helpers.js
+++ b/helpers/helpers.js
@@ -312,6 +312,9 @@ function examples (options) {
       if (matches) {
         var exampleLangSubtag = matches[1]
         lines[0] = lines[0].replace(matches[0], '')
+        if (lines[0].length === 0) {
+          lines.splice(0, 1)
+        }
       }
       var exampleLang = exampleLangSubtag || exampleLangOptions
 
@@ -326,7 +329,7 @@ function examples (options) {
       }
 
       if (!(/```/.test(example) || exampleLang === 'off')) {
-        example = util.format('```%s\n%s\n```', exampleLang, example)
+        example = util.format('```%s%s```', exampleLang ? exampleLang + '\n' : '', example ? example + '\n' : '')
       }
 
       return prev + options.fn({caption: caption, example: example})

--- a/helpers/helpers.js
+++ b/helpers/helpers.js
@@ -305,23 +305,25 @@ function examples (options) {
   if (this.examples) {
     return this.examples.reduce(function (prev, example) {
       var lines = example.split(/\r\n|\r|\n/)
-      var matches = lines[0].match(/\s*<caption>(.*?)<\/caption>\s*/)
-      var caption
 
+      /* Process @lang */
+      var exampleLangOptions = ddata.option('example-lang', options)
+      var matches = lines[0].match(/@lang\s+(\w+)\s*/)
+      if (matches) {
+        var exampleLangSubtag = matches[1]
+        lines[0] = lines[0].replace(matches[0], '')
+      }
+      var exampleLang = exampleLangSubtag || exampleLangOptions
+
+      /* Process <caption> and update example */
+      matches = lines[0].match(/\s*<caption>(.*?)<\/caption>\s*/)
+      var caption
       if (matches) {
         caption = matches[1]
         example = lines.slice(1).join('\n')
+      } else if (exampleLangSubtag) {
+        example = lines.join('\n')
       }
-
-      var exampleLangOptions = ddata.option('example-lang', options)
-      matches = example.match(/@lang\s+(\w+)\s*/)
-
-      if (matches) {
-        var exampleLangSubtag = matches[1]
-        example = example.replace(matches[0], '')
-      }
-
-      var exampleLang = exampleLangSubtag || exampleLangOptions
 
       if (!(/```/.test(example) || exampleLang === 'off')) {
         example = util.format('```%s\n%s\n```', exampleLang, example)


### PR DESCRIPTION
## Issue

`@lang` tag not processed if the `<caption>` and `@lang` tags are both included into the `@example` source directly; I assume this is not intended, as otherwise `@lang` processing would be conditionally dependent on presence of `<caption>`.

Thus this is a bug, and the reason is, that when `<caption>` is present, the `example` has first line removed, and processing is continued for `@lang` on modified `example`, which already does not have the original line.

## Goals

- Keep existing behavior, as there are special cases, such as trailing commentary.
- Effectively keep the design/logic.
- Maintain existing coding style.
- Keep changes to minimum.

## Solution

- Process `@lang` before `<caption>`, for the special case `<caption>@lang cmd comment</caption>`; Otherwise in such case language would be processed, but still remain within caption, which is inappropriate.
- Modify the `lines` first, instead of `example` object itself, and assign the modified `lines`(if modification happened) to `example` after processing `<caption>` and `@lang`, as it minimizes the needed changes.

## Note

- There are behaviors, such as `<capt@lang cmd ion>comment</caption>`, which I did not touch due to reasons described in goals.
- There is currently a workaround of using ```` ``` ```` directly in the source.