### PR TITLE
Support both caption and lang sub tag for examples

### DIFF
--- a/helpers/helpers.js
+++ b/helpers/helpers.js
@@ -314,7 +314,7 @@ function examples (options) {
       }
 
       var exampleLangOptions = ddata.option('example-lang', options)
-      matches = example.match(/@lang\s+(\w+)\s*/)
+      matches = lines[0].match(/@lang\s+(\w+)\s*/)
 
       if (matches) {
         exampleLangSubtag = matches[1]

--- a/helpers/helpers.js
+++ b/helpers/helpers.js
@@ -307,18 +307,21 @@ function examples (options) {
       var lines = example.split(/\r\n|\r|\n/)
       var matches = lines[0].match(/\s*<caption>(.*?)<\/caption>\s*/)
       var caption
+      var exampleLangSubtag
 
       if (matches) {
         caption = matches[1]
-        example = lines.slice(1).join('\n')
       }
 
       var exampleLangOptions = ddata.option('example-lang', options)
       matches = example.match(/@lang\s+(\w+)\s*/)
 
       if (matches) {
-        var exampleLangSubtag = matches[1]
-        example = example.replace(matches[0], '')
+        exampleLangSubtag = matches[1]
+      }
+
+      if (caption || exampleLangSubtag) {
+        example = lines.slice(1).join('\n')
       }
 
       var exampleLang = exampleLangSubtag || exampleLangOptions


### PR DESCRIPTION
When trying to specify both a caption and a language for jsdoc examples the language is simply ignored.

This pull request should make it possible to include both by using one of below methods:

```js
/**
 * Cleanest method IMO
 * @example <caption>index.html</caption> @lang html
 * <div></div>
 */

/**
 * I think the lang tag at the end is cleaner, but this still works
 * @example @lang html <caption>index.html</caption>
 * <div></div>
 */

/**
 * Still works with caption on a new line
 * @example
 * <caption>index.html</caption> @lang html
 * <div></div>
 */
```

This won't work:

```js
/**
 * Both lang and caption must be on the same line to work
 * @example @lang html
 * <caption>index.html</caption> 
 * <div></div>
 */

/**
 * Using lang first will cause the example to close and thus be empty
 * @example
 * @lang html <caption>index.html</caption>
 * <div></div>
 */
```

To explain the commit, instead of deleting the first line if a caption is present, I extract both caption and lang from the first line (if available). Then if either of them is found, I delete the first line.