### PR TITLE
Escape underscores in markdown

### DIFF
--- a/helpers/helpers.js
+++ b/helpers/helpers.js
@@ -37,7 +37,7 @@ Escape special markdown characters
 */
 function escape (input) {
   if (typeof input !== 'string') return null
-  return input.replace(/([\*|])/g, '\\$1')
+  return input.replace(/([\*|_])/g, '\\$1')
 }
 
 /**

--- a/partials/shared/signature/sig-name.hbs
+++ b/partials/shared/signature/sig-name.hbs
@@ -4,7 +4,7 @@
 {{{@codeOpen}~}}
 {{#if @prefix}}{{@prefix}} {{/if~}}
 {{@parent~}}
-{{@accessSymbol}}{{#if (isEvent)}}"{{{name}}}"{{else}}{{{name}}}{{/if~}}
+{{@accessSymbol}}{{#if (isEvent)}}"{{{name}}}"{{else}}{{{escape name}}}{{/if~}}
 {{#if @methodSign}}{{#if (isEvent)}} {{@methodSign}}{{else}}{{@methodSign}}{{/if}}{{/if~}}
 {{{@codeClose}~}}
 {{#if @returnSymbol}} {{@returnSymbol}}{{/if~}}


### PR DESCRIPTION
Currently, idenfitiers containing underscores are rendered incorrectly:
words enclosed by underscores get an italic font style. Underscores should be
escaped to prevent this issue.

An example from a generated list of constants:

![image](https://user-images.githubusercontent.com/1219904/46921767-afedaf80-cfff-11e8-97b8-a12a0a368937.png)

When escaping underscores it renders correctly:

![image](https://user-images.githubusercontent.com/1219904/46921784-e1ff1180-cfff-11e8-97f4-84c80be90878.png)
