### PR TITLE
Fix issue #61

### DIFF
--- a/helpers/ddata.js
+++ b/helpers/ddata.js
@@ -618,10 +618,10 @@ function parseLink (text) {
   if (!text) return ''
   var results = []
   var matches = null
-  var link1 = /{@link (\S+?)}/g // {@link someSymbol}
-  var link2 = /\[(.+?)\]{@link (\S+?)}/g // [caption here]{@link someSymbol}
-  var link3 = /{@link ([^\s}]+?)\|(.+?)}/g // {@link someSymbol|caption here}
-  var link4 = /{@link ([^\s}\|]+?) (.+?)}/g // {@link someSymbol Caption Here}
+  var link1 = /{@link\s+([^\s}|]+?)\s*}/g // {@link someSymbol}
+  var link2 = /\[([^\]]+?)\]{@link\s+([^\s}|]+?)\s*}/g // [caption here]{@link someSymbol}
+  var link3 = /{@link\s+([^\s}|]+?)\s*\|([^}]+?)}/g // {@link someSymbol|caption here}
+  var link4 = /{@link\s+([^\s}|]+?)\s+([^}|]+?)}/g // {@link someSymbol Caption Here}
 
   while ((matches = link4.exec(text)) !== null) {
     results.push({


### PR DESCRIPTION
Fixes the issue #61 and other situations where a line break somewhere in a {@link ...} tag will stop jsdoc2md from generating a correct link.

The fix will allow whitespaces and newlines in the {@link ...} tag except in the "namepathOrURL" part. See: http://usejsdoc.org/tags-inline-link.html

This allows to have line breaks in the {@link ...} tag like for example:

```js
    /**
     * {@link Test1}
     * {@link
     * Test2}
     * {@link
     *  Test3}
     * {@link     Test4}
     * {@link     Test5 }
     * {@link     Test6
     * }
     * {@link     Test7
     *  }
     * {@link     Test8    }
     *
     * {@link Test9|Caption9}
     * {@link TestA|
     * CaptionA}
     * {@link TestB|
     *  CaptionB}
     * {@link TestC|    CaptionC}
     * {@link TestD|    CaptionD }
     * {@link TestE|    CaptionE
     * }
     * {@link TestF|    CaptionF
     *  }
     * {@link TestG|    CaptionG    }
     *
     * {@link TestH |CaptionH}
     * {@link TestI |
     * CaptionI}
     * {@link TestJ |
     *  CaptionJ}
     * {@link TestK |    CaptionK}
     * {@link TestL |    CaptionL }
     * {@link TestM |    CaptionM
     * }
     * {@link TestN |    CaptionN
     *  }
     * {@link TestO |    CaptionO    }
     *
     * {@link TestP Caption with long textP}
     * {@link TestQ
     * Caption with long textQ}
     * {@link TestR
     *   Caption with long textR}
     * {@link TestS     Caption with long textS}
     * {@link TestT     Caption with long textT }
     * {@link TestU     Caption with long textU
     * }
     * {@link TestV     Caption with long textV
     *  }
     * {@link TestW     Caption with long textW    }
     */
```