### PR TITLE
Enable instance only typicalname for all scopes

### DIFF
--- a/helpers/ddata.js
+++ b/helpers/ddata.js
@@ -687,8 +687,6 @@ function parentName (options) {
       if (this.scope === 'instance') {
         var name = parent.typicalname || parent.name
         return instantiate(name)
-      } else if (this.scope === 'static' && !(parent.kind === 'class' || parent.kind === 'constructor')) {
-        return parent.typicalname || parent.name
       } else {
         return parent.name
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dmd",
   "author": "Lloyd Brookes <75pound@gmail.com>",
-  "version": "3.0.13",
+  "version": "3.0.14-patch1",
   "description": "dmd (document with markdown) is a collection of handlebars templates for generating markdown documentation from jsdoc-parse input data. It is the default template set used by jsdoc-to-markdown.",
   "license": "MIT",
   "repository": "https://github.com/75lb/dmd.git",


### PR DESCRIPTION
Enables typicalname to be used anywhere instead of limited to class. See #66 