### PR TITLE
Enable typicalname for anything with instance members

### DIFF
--- a/helpers/ddata.js
+++ b/helpers/ddata.js
@@ -687,7 +687,7 @@ function parentName (options) {
       if (this.scope === 'instance') {
         var name = parent.typicalname || parent.name
         return instantiate(name)
-      } else if (this.scope === 'static' && !(parent.kind === 'class' || parent.kind === 'constructor')) {
+      } else if (this.scope === 'static' && !(parent.kind === 'class' || parent.kind === 'constructor') && _children.call(parent, options).filter(where({ scope: 'instance'})).length === 0) {
         return parent.typicalname || parent.name
       } else {
         return parent.name

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dmd",
   "author": "Lloyd Brookes <75pound@gmail.com>",
-  "version": "3.0.13",
+  "version": "3.0.14-patch2",
   "description": "dmd (document with markdown) is a collection of handlebars templates for generating markdown documentation from jsdoc-parse input data. It is the default template set used by jsdoc-to-markdown.",
   "license": "MIT",
   "repository": "https://github.com/75lb/dmd.git",


### PR DESCRIPTION
Proper fix for #66 that enables typicalname instance member separation for any object that has instance members such as mixins or functions, not only classes.

Sample 1
```js
/**
 * My should be documented as myFunction
 * @typicalname otherFunction
 * @this myFunction
 */
function myFunction() {
    /**
     * Should be documented as otherFunction.instanceMember
     */
    this.instanceMember = 1;
}

/**
 * Should be documented as myFunction.staticValue
 */
myFunction.staticValue = 2;

myFunction.call(otherFunction);
```

Sample 2
```js
/**
 * Should be documented as myObj
 * @typicalname otherObj
 */
var myObj = {
    /** 
     *  Documented as otherObj.first
     */
    first: "hej",
    /** 
     * Documented as otherObj.second
     */
    second: true
}

this.otherObj = myObj;
```

Sample 3
```js
/**
 * @module underscore
 * @typicalname _
 */

/**
 * Should be documented as _.findWhere()
 */
exports.findWhere = function () { }

/**
 * Should be documented as _.flatten()
 */
exports.flatten = function () { }
```