### PR TITLE
Changes `anchorName` to link headings by ID

### DIFF
--- a/partials/all-docs/docs/header.hbs
+++ b/partials/all-docs/docs/header.hbs
@@ -1,3 +1,1 @@
-<a name="{{{anchorName}}}"></a>
-
 {{>heading-indent}}{{>sig-name}}


### PR DESCRIPTION
This may address jsdoc2md/jsdoc-to-markdown#122 and 
jsdoc2md/jsdoc-to-markdown#125


Tests with MarkDown rendering on GitHub show that, heading text is 
striped of most non-letter and non-number characters (underscores and 
hyphens seem to remain), plus letters are lowercased, leading and 
trailing spaces are trimmed, duplicate spaces are treated as one and, 
spaces are turned into hyphens...


```JavaScript
const test_string = '(2; muc{hTi   me  @# t[h)e k3b]Oa}rd?';

const id_string = test_string.toLowerCase()
                             .replace(/[^a-z0-9_ ]/g, '')
                             .replace(/ +/g, '-');


console.log('id_string -> ' + id_string);
//> 2-muchtime-the-k3board
```


... above code-block _should_ replicate the stripping that happens 
automatically and allow for removal of `<a name="{{{anchorName}}}"></a>` 
from the `partials/all-docs/header.hbs` file.


> Note while show within the changes for this commit it is **not** 
suggested to merge `partials/all-docs/header.hbs` file changes.


Changes made to `anchorName` function (within the `ddata.js` file), 
reused as much code from elsewhere within the code base. And so far 
seems to operate correctly regardless of _`backticks`_ option.


To enable this new branch in logic set `id-headings` to `true` within 
configurations, eg...


**`package.json` _snippet_**


```JSON
{
  "jsdoc2md": {
    "name-format": "backticks",
    "id-headings": true
  }
}
```


... because, default behavior likely should be preserved for those that 
are depending upon the `name` attributes.