### PR TITLE
Support jsdoc link types and settings

### DIFF
--- a/helpers/ddata.js
+++ b/helpers/ddata.js
@@ -611,7 +611,8 @@ function methodSig () {
 /**
  * extracts url and caption data from @link tags
  * @param {string} - a string containing one or more {@link} tags
- * @returns {Array.<{original: string, caption: string, url: string}>}
+ * @param {object} - `dmdOptions`; link formatting is influenced by the `clever-links` and `monospace-links` values
+ * @returns {Array.<{original: string, caption: string, url: string, format: 'code'|'plain'}>}
  * @static
  */
 function parseLink (text, dmdOptions) {

--- a/helpers/helpers.js
+++ b/helpers/helpers.js
@@ -44,12 +44,14 @@ replaces {@link} tags with markdown links in the suppied input text
 */
 function inlineLinks (text, options) {
   if (text) {
-    const links = ddata.parseLink(text)
+    const dmdOptions = options.data.root.options
+    const links = ddata.parseLink(text, dmdOptions)
     links.forEach(function (link) {
+      const captionFmt = link.format === 'code' ? '`' : ''
       const linked = ddata._link(link.url, options)
       if (link.caption === link.url) link.caption = linked.name
       if (linked.url) link.url = linked.url
-      text = text.replace(link.original, '[' + link.caption + '](' + link.url + ')')
+      text = text.replace(link.original, '[' + captionFmt + link.caption + captionFmt + '](' + link.url + ')')
     })
   }
   return text

--- a/helpers/helpers.js
+++ b/helpers/helpers.js
@@ -40,7 +40,7 @@ function escape (input) {
 }
 
 /**
-replaces {@link} tags with markdown links in the suppied input text
+replaces {@link}, {@linkplain}, and {@linkcode} tags with markdown links in the supplied input text
 */
 function inlineLinks (text, options) {
   if (text) {

--- a/index.js
+++ b/index.js
@@ -31,7 +31,6 @@ function dmd (templateData, options) {
 
 dmd.async = function (templateData, options) {
   options = new DmdOptions(options)
-  console.error('options (a):', options) // DEBUG
   if (skipCache(options)) {
     return Promise.resolve(generate(templateData, options))
   } else {
@@ -45,7 +44,6 @@ dmd.async = function (templateData, options) {
 dmd.cache = new Cache({ dir: path.join(require('os').tmpdir(), 'dmd') })
 
 function generate (templateData, options) {
-  console.error('generate') // DEBUG
   const fs = require('fs')
   const path = require('path')
   const arrayify = require('array-back')
@@ -82,7 +80,6 @@ function generate (templateData, options) {
 
   templateData = arrayify(templateData)
   options = Object.assign(new DmdOptions(), options)
-  console.error('options (c):', options) // DEBUG
   options.plugin = arrayify(options.plugin)
   options._depth = 0
   options._indexDepth = 0

--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ function dmd (templateData, options) {
 
 dmd.async = function (templateData, options) {
   options = new DmdOptions(options)
+  console.error('options (a):', options) // DEBUG
   if (skipCache(options)) {
     return Promise.resolve(generate(templateData, options))
   } else {
@@ -44,6 +45,7 @@ dmd.async = function (templateData, options) {
 dmd.cache = new Cache({ dir: path.join(require('os').tmpdir(), 'dmd') })
 
 function generate (templateData, options) {
+  console.error('generate') // DEBUG
   const fs = require('fs')
   const path = require('path')
   const arrayify = require('array-back')
@@ -80,6 +82,7 @@ function generate (templateData, options) {
 
   templateData = arrayify(templateData)
   options = Object.assign(new DmdOptions(), options)
+  console.error('options (c):', options) // DEBUG
   options.plugin = arrayify(options.plugin)
   options._depth = 0
   options._indexDepth = 0

--- a/lib/dmd-options.js
+++ b/lib/dmd-options.js
@@ -81,6 +81,20 @@ function DmdOptions (options) {
   this['member-index-format'] = 'grouped'
 
   /**
+   * If true, \{@link XXX} tags are rendered in normal text if XXX is a URL and monospace (code) format otherwise.
+   * @type {boolean}
+   * @dafult
+   */
+  this['clever-links'] = false
+
+  /**
+   * If true, all \{@link} tags are rendered in monospace (code) format. This setting is ignored in `clever-links` is true.
+   * @type {boolean}
+   * @default
+   */
+  this['monospace-links'] = false
+
+  /**
    * Show identifiers marked `@private` in the output.
    * @type {boolean}
    * @default false

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "reduce-flatten": "^3.0.1",
         "reduce-unique": "^2.0.1",
         "reduce-without": "^1.0.1",
+        "regex-repo": "^5.0.0",
         "test-value": "^3.0.0",
         "walk-back": "^5.1.0"
       },
@@ -706,6 +707,14 @@
       "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
       "integrity": "sha512-ofhi8kjIje6npGozTip9Fr8iecmYfEbS06i0JnIg+rh51KakryWF4+jX8lLKZVhy6N+ID45WYSFCxPOdTWCzNg==",
       "license": "MIT"
+    },
+    "node_modules/regex-repo": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/regex-repo/-/regex-repo-5.0.0.tgz",
+      "integrity": "sha512-6sVOLr5uq9AxMiRh9Eu9ip66kk4viqnOk8ZYqWihDmXIRZqLqEv1DKyDLwVyOCwaErjhXmBKvAYwtQ9cC2GDSQ==",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/source-map": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "reduce-flatten": "^3.0.1",
     "reduce-unique": "^2.0.1",
     "reduce-without": "^1.0.1",
+    "regex-repo": "^5.0.0",
     "test-value": "^3.0.0",
     "walk-back": "^5.1.0"
   },

--- a/test/ddata/parseLink.js
+++ b/test/ddata/parseLink.js
@@ -213,112 +213,129 @@ tom.test('multiple {@link(plain/code) someSymbol Caption here}', function () {
   a.deepEqual(ddata.parseLink(text), result)
 })
 
-tom.test("'clever-links' true, 'monospace-links' undefined", function() {
-  // {@link symbol catption} style
-  const text = 'blah {@linkplain thingOne Caption one} blah {@linkcode ftp://url-two.tld Caption two} whatever {@link thingThree Caption three} !@ {@link https://url-four.com Caption four} ok '
+// {@link symbol catption} style
+const allLinksText = 'blah {@linkplain thingOne Caption one} blah {@linkcode ftp://url-two.tld Caption two} whatever {@link thingThree Caption three} !@ {@link https://url-four.com Caption four} ok '
   // {@link symbol|caption} style
   + '{@linkplain thingFive|caption five} nah {@linkcode git://url-six.com|caption six} ??? {@link thingSeven|caption seven} {@link https://url-eight.net|caption eight} @typedef '
   // [caption]{@link symbol} style
   + '[caption nine]{@linkplain symbolNine} ach [caption ten]{@linkcode http://url.ten.com} 2434 [caption eleven]{@link symbolEleven} http://foo.com [caption twelve]{@link http://url.12.com} whawha'
   // {@link symbol} style
   + '{@linkplain symbolThirteen} fee {@linkcode proto://fourteen.asbf} blb {@link symbolFifteen} geez {@link telnet://16.123.123.123}'
-  const result = [
-    { 
-      original: '{@linkplain thingOne Caption one}',
-      caption: 'Caption one',
-      url: 'thingOne',
-      format: 'plain'
-    },
-    {
-      original: '{@linkcode ftp://url-two.tld Caption two}',
-      caption: 'Caption two',
-      url: 'ftp://url-two.tld',
-      format: 'code'
-    },
-    {
-      original: '{@link thingThree Caption three}',
-      caption: 'Caption three',
-      url: 'thingThree',
-      format: 'code',
-    },
-    {
-      original: '{@link https://url-four.com Caption four}',
-      caption: 'Caption four',
-      url: 'https://url-four.com',
-      format: 'plain'
-    },
-    {
-      original: '{@linkplain thingFive|caption five}',
-      caption: 'caption five',
-      url: 'thingFive',
-      format: 'plain'
-    },
-    {
-      original: '{@linkcode git://url-six.com|caption six}',
-      caption: 'caption six',
-      url: 'git://url-six.com',
-      format: 'code'
-    },
-    {
-      original: '{@link thingSeven|caption seven}',
-      caption: 'caption seven',
-      url: 'thingSeven',
-      format: 'code',
-    },
-    {
-      original: '{@link https://url-eight.net|caption eight}',
-      caption: 'caption eight',
-      url: 'https://url-eight.net',
-      format: 'plain'
-    },
-    {
-      original: '[caption nine]{@linkplain symbolNine}',
-      caption: 'caption nine',
-      url: 'symbolNine',
-      format: 'plain'
-    },
-    {
-      original: '[caption ten]{@linkcode http://url.ten.com}',
-      caption: 'caption ten',
-      url: 'http://url.ten.com',
-      format: 'code'
-    },
-    {
-      original: '[caption eleven]{@link symbolEleven}',
-      caption: 'caption eleven',
-      url: 'symbolEleven',
-      format: 'code'
-    },
-    {
-      original: '[caption twelve]{@link http://url.12.com}',
-      caption: 'caption twelve',
-      url: 'http://url.12.com',
-      format: 'plain'
-    },
-    {
-      original: '{@linkplain symbolThirteen}',
-      caption: 'symbolThirteen',
-      url: 'symbolThirteen',
-      format: 'plain',
-    },
-    {
-      original: '{@linkcode proto://fourteen.asbf}',
-      caption: 'proto://fourteen.asbf',
-      url: 'proto://fourteen.asbf',
-      format: 'code'
-    },
-    {
-      original: '{@link symbolFifteen}',
-      caption: 'symbolFifteen',
-      url: 'symbolFifteen',
-      format: 'code'
-    },
-    {
-      original: '{@link telnet://16.123.123.123}',
-      caption: 'telnet://16.123.123.123',
-      url: 'telnet://16.123.123.123',
-      format: 'plain'
+
+const cleverLinksResults = [
+  { 
+    original: '{@linkplain thingOne Caption one}',
+    caption: 'Caption one',
+    url: 'thingOne',
+    format: 'plain'
+  },
+  {
+    original: '{@linkcode ftp://url-two.tld Caption two}',
+    caption: 'Caption two',
+    url: 'ftp://url-two.tld',
+    format: 'code'
+  },
+  {
+    original: '{@link thingThree Caption three}',
+    caption: 'Caption three',
+    url: 'thingThree',
+    format: 'code',
+  },
+  {
+    original: '{@link https://url-four.com Caption four}',
+    caption: 'Caption four',
+    url: 'https://url-four.com',
+    format: 'plain'
+  },
+  {
+    original: '{@linkplain thingFive|caption five}',
+    caption: 'caption five',
+    url: 'thingFive',
+    format: 'plain'
+  },
+  {
+    original: '{@linkcode git://url-six.com|caption six}',
+    caption: 'caption six',
+    url: 'git://url-six.com',
+    format: 'code'
+  },
+  {
+    original: '{@link thingSeven|caption seven}',
+    caption: 'caption seven',
+    url: 'thingSeven',
+    format: 'code',
+  },
+  {
+    original: '{@link https://url-eight.net|caption eight}',
+    caption: 'caption eight',
+    url: 'https://url-eight.net',
+    format: 'plain'
+  },
+  {
+    original: '[caption nine]{@linkplain symbolNine}',
+    caption: 'caption nine',
+    url: 'symbolNine',
+    format: 'plain'
+  },
+  {
+    original: '[caption ten]{@linkcode http://url.ten.com}',
+    caption: 'caption ten',
+    url: 'http://url.ten.com',
+    format: 'code'
+  },
+  {
+    original: '[caption eleven]{@link symbolEleven}',
+    caption: 'caption eleven',
+    url: 'symbolEleven',
+    format: 'code'
+  },
+  {
+    original: '[caption twelve]{@link http://url.12.com}',
+    caption: 'caption twelve',
+    url: 'http://url.12.com',
+    format: 'plain'
+  },
+  {
+    original: '{@linkplain symbolThirteen}',
+    caption: 'symbolThirteen',
+    url: 'symbolThirteen',
+    format: 'plain',
+  },
+  {
+    original: '{@linkcode proto://fourteen.asbf}',
+    caption: 'proto://fourteen.asbf',
+    url: 'proto://fourteen.asbf',
+    format: 'code'
+  },
+  {
+    original: '{@link symbolFifteen}',
+    caption: 'symbolFifteen',
+    url: 'symbolFifteen',
+    format: 'code'
+  },
+  {
+    original: '{@link telnet://16.123.123.123}',
+    caption: 'telnet://16.123.123.123',
+    url: 'telnet://16.123.123.123',
+    format: 'plain'
+  }
+]
+
+tom.test("'clever-links' true, 'monospace-links' undefined", function() {
+  a.deepEqual(ddata.parseLink(allLinksText, { 'clever-links': true }), cleverLinksResults)
+})
+
+tom.test("'clever-links' true overrides 'monospace-links' true", function() {
+  a.deepEqual(ddata.parseLink(allLinksText, { 'clever-links': true, 'monospace-links': true }), cleverLinksResults)
+})
+
+tom.test("'monospace-links' set all {@link}s to 'code' format", function() {
+  const monospaceLinkResults = cleverLinksResults.map((result) => {
+    const newResult = Object.assign({}, result)
+    if (!/@link(?:code|plain)/.test(result.original)) {
+      newResult.format = 'code'
     }
-  ]
-  a.deepEqual(ddata.parseLink(text, { 'clever-links': true }), result)
+    return newResult
+  })
+  a.deepEqual(ddata.parseLink(allLinksText, { 'monospace-links': true }), monospaceLinkResults)
 })

--- a/test/ddata/parseLink.js
+++ b/test/ddata/parseLink.js
@@ -6,7 +6,19 @@ const tom = module.exports = new Tom('parseLink')
 
 tom.test('{@link someSymbol}', function () {
   const text = 'blah {@link someSymbol}'
-  const result = [{ original: '{@link someSymbol}', caption: 'someSymbol', url: 'someSymbol' }]
+  const result = [{ original: '{@link someSymbol}', caption: 'someSymbol', url: 'someSymbol', format: 'plain' }]
+  a.deepEqual(ddata.parseLink(text), result)
+})
+
+tom.test('{@linkcode someSymbol}', function () {
+  const text = 'blah {@linkcode someSymbol}'
+  const result = [{ original: '{@linkcode someSymbol}', caption: 'someSymbol', url: 'someSymbol', format: 'code' }]
+  a.deepEqual(ddata.parseLink(text), result)
+})
+
+tom.test('{@linkplain someSymbol}', function () {
+  const text = 'blah {@linkplain someSymbol}'
+  const result = [{ original: '{@linkplain someSymbol}', caption: 'someSymbol', url: 'someSymbol', format: 'plain' }]
   a.deepEqual(ddata.parseLink(text), result)
 })
 
@@ -15,7 +27,30 @@ tom.test('{@link http://some.url.com}', function () {
   const result = [{
     original: '{@link http://some.url.com}',
     caption: 'http://some.url.com',
-    url: 'http://some.url.com'
+    url: 'http://some.url.com',
+    format: 'plain'
+  }]
+  a.deepEqual(ddata.parseLink(text), result)
+})
+
+tom.test('{@linkcode http://some.url.com}', function () {
+  const text = 'blah {@linkcode http://some.url.com} blah'
+  const result = [{
+    original: '{@linkcode http://some.url.com}',
+    caption: 'http://some.url.com',
+    url: 'http://some.url.com',
+    format: 'code'
+  }]
+  a.deepEqual(ddata.parseLink(text), result)
+})
+
+tom.test('{@linkplain http://some.url.com}', function () {
+  const text = 'blah {@linkplain http://some.url.com} blah'
+  const result = [{
+    original: '{@linkplain http://some.url.com}',
+    caption: 'http://some.url.com',
+    url: 'http://some.url.com',
+    format: 'plain'
   }]
   a.deepEqual(ddata.parseLink(text), result)
 })
@@ -26,12 +61,14 @@ tom.test('multiple {@link http://some.url.com}', function () {
     {
       original: '{@link http://one.url.com}',
       caption: 'http://one.url.com',
-      url: 'http://one.url.com'
+      url: 'http://one.url.com',
+      format: 'plain'
     },
     {
       original: '{@link http://two.url.com}',
       caption: 'http://two.url.com',
-      url: 'http://two.url.com'
+      url: 'http://two.url.com',
+      format: 'plain'
     }
   ]
   a.deepEqual(ddata.parseLink(text), expected)
@@ -42,7 +79,30 @@ tom.test('[caption here]{@link someSymbol}', function () {
   const result = [{
     original: '[caption here]{@link someSymbol}',
     caption: 'caption here',
-    url: 'someSymbol'
+    url: 'someSymbol',
+    format: 'plain'
+  }]
+  a.deepEqual(ddata.parseLink(text), result)
+})
+
+tom.test('[caption here]{@linkcode someSymbol}', function () {
+  const text = 'blah [caption here]{@linkcode someSymbol} blah'
+  const result = [{
+    original: '[caption here]{@linkcode someSymbol}',
+    caption: 'caption here',
+    url: 'someSymbol',
+    format: 'code'
+  }]
+  a.deepEqual(ddata.parseLink(text), result)
+})
+
+tom.test('[caption here]{@linkplain someSymbol}', function () {
+  const text = 'blah [caption here]{@linkplain someSymbol} blah'
+  const result = [{
+    original: '[caption here]{@linkplain someSymbol}',
+    caption: 'caption here',
+    url: 'someSymbol',
+    format: 'plain'
   }]
   a.deepEqual(ddata.parseLink(text), result)
 })
@@ -53,12 +113,14 @@ tom.test('multiple [caption here]{@link someSymbol}', function () {
     {
       original: '[caption one]{@link thingOne}',
       caption: 'caption one',
-      url: 'thingOne'
+      url: 'thingOne',
+      format: 'plain'
     },
     {
       original: '[caption two]{@link thingTwo}',
       caption: 'caption two',
-      url: 'thingTwo'
+      url: 'thingTwo',
+      format: 'plain'
     }
   ]
   a.deepEqual(ddata.parseLink(text), result)
@@ -69,7 +131,8 @@ tom.test('[caption here]{@link http://some.url.com}', function () {
   const result = [{
     original: '[caption here]{@link http://some.url.com}',
     caption: 'caption here',
-    url: 'http://some.url.com'
+    url: 'http://some.url.com',
+    format: 'plain'
   }]
   a.deepEqual(ddata.parseLink(text), result)
 })
@@ -80,12 +143,33 @@ tom.test('multiple {@link someSymbol|caption here}', function () {
     {
       original: '{@link thingOne|caption one}',
       caption: 'caption one',
-      url: 'thingOne'
+      url: 'thingOne',
+      format: 'plain'
     },
     {
       original: '{@link thingTwo|caption two}',
       caption: 'caption two',
-      url: 'thingTwo'
+      url: 'thingTwo',
+      format: 'plain'
+    }
+  ]
+  a.deepEqual(ddata.parseLink(text), result)
+})
+
+tom.test('mixed {@link(plain/code) someSymbol|caption here}', function () {
+  const text = 'blah {@linkplain thingOne|caption one} blah {@linkcode thingTwo|caption two} whatever'
+  const result = [
+    {
+      original: '{@linkplain thingOne|caption one}',
+      caption: 'caption one',
+      url: 'thingOne',
+      format: 'plain'
+    },
+    {
+      original: '{@linkcode thingTwo|caption two}',
+      caption: 'caption two',
+      url: 'thingTwo',
+      format: 'code'
     }
   ]
   a.deepEqual(ddata.parseLink(text), result)
@@ -97,13 +181,144 @@ tom.test('multiple {@link someSymbol Caption here}', function () {
     {
       original: '{@link thingOne Caption one}',
       caption: 'Caption one',
-      url: 'thingOne'
+      url: 'thingOne',
+      format: 'plain'
     },
     {
       original: '{@link thingTwo Caption two}',
       caption: 'Caption two',
-      url: 'thingTwo'
+      url: 'thingTwo',
+      format: 'plain'
     }
   ]
   a.deepEqual(ddata.parseLink(text), result)
+})
+
+tom.test('multiple {@link(plain/code) someSymbol Caption here}', function () {
+  const text = 'blah {@linkplain thingOne Caption one} blah {@linkcode thingTwo Caption two} whatever'
+  const result = [
+    {
+      original: '{@linkplain thingOne Caption one}',
+      caption: 'Caption one',
+      url: 'thingOne',
+      format: 'plain'
+    },
+    {
+      original: '{@linkcode thingTwo Caption two}',
+      caption: 'Caption two',
+      url: 'thingTwo',
+      format: 'code'
+    }
+  ]
+  a.deepEqual(ddata.parseLink(text), result)
+})
+
+tom.test("'clever-links' true, 'monospace-links' undefined", function() {
+  // {@link symbol catption} style
+  const text = 'blah {@linkplain thingOne Caption one} blah {@linkcode ftp://url-two.tld Caption two} whatever {@link thingThree Caption three} !@ {@link https://url-four.com Caption four} ok '
+  // {@link symbol|caption} style
+  + '{@linkplain thingFive|caption five} nah {@linkcode git://url-six.com|caption six} ??? {@link thingSeven|caption seven} {@link https://url-eight.net|caption eight} @typedef '
+  // [caption]{@link symbol} style
+  + '[caption nine]{@linkplain symbolNine} ach [caption ten]{@linkcode http://url.ten.com} 2434 [caption eleven]{@link symbolEleven} http://foo.com [caption twelve]{@link http://url.12.com} whawha'
+  // {@link symbol} style
+  + '{@linkplain symbolThirteen} fee {@linkcode proto://fourteen.asbf} blb {@link symbolFifteen} geez {@link telnet://16.123.123.123}'
+  const result = [
+    { 
+      original: '{@linkplain thingOne Caption one}',
+      caption: 'Caption one',
+      url: 'thingOne',
+      format: 'plain'
+    },
+    {
+      original: '{@linkcode ftp://url-two.tld Caption two}',
+      caption: 'Caption two',
+      url: 'ftp://url-two.tld',
+      format: 'code'
+    },
+    {
+      original: '{@link thingThree Caption three}',
+      caption: 'Caption three',
+      url: 'thingThree',
+      format: 'code',
+    },
+    {
+      original: '{@link https://url-four.com Caption four}',
+      caption: 'Caption four',
+      url: 'https://url-four.com',
+      format: 'plain'
+    },
+    {
+      original: '{@linkplain thingFive|caption five}',
+      caption: 'caption five',
+      url: 'thingFive',
+      format: 'plain'
+    },
+    {
+      original: '{@linkcode git://url-six.com|caption six}',
+      caption: 'caption six',
+      url: 'git://url-six.com',
+      format: 'code'
+    },
+    {
+      original: '{@link thingSeven|caption seven}',
+      caption: 'caption seven',
+      url: 'thingSeven',
+      format: 'code',
+    },
+    {
+      original: '{@link https://url-eight.net|caption eight}',
+      caption: 'caption eight',
+      url: 'https://url-eight.net',
+      format: 'plain'
+    },
+    {
+      original: '[caption nine]{@linkplain symbolNine}',
+      caption: 'caption nine',
+      url: 'symbolNine',
+      format: 'plain'
+    },
+    {
+      original: '[caption ten]{@linkcode http://url.ten.com}',
+      caption: 'caption ten',
+      url: 'http://url.ten.com',
+      format: 'code'
+    },
+    {
+      original: '[caption eleven]{@link symbolEleven}',
+      caption: 'caption eleven',
+      url: 'symbolEleven',
+      format: 'code'
+    },
+    {
+      original: '[caption twelve]{@link http://url.12.com}',
+      caption: 'caption twelve',
+      url: 'http://url.12.com',
+      format: 'plain'
+    },
+    {
+      original: '{@linkplain symbolThirteen}',
+      caption: 'symbolThirteen',
+      url: 'symbolThirteen',
+      format: 'plain',
+    },
+    {
+      original: '{@linkcode proto://fourteen.asbf}',
+      caption: 'proto://fourteen.asbf',
+      url: 'proto://fourteen.asbf',
+      format: 'code'
+    },
+    {
+      original: '{@link symbolFifteen}',
+      caption: 'symbolFifteen',
+      url: 'symbolFifteen',
+      format: 'code'
+    },
+    {
+      original: '{@link telnet://16.123.123.123}',
+      caption: 'telnet://16.123.123.123',
+      url: 'telnet://16.123.123.123',
+      format: 'plain'
+    }
+  ]
+  a.deepEqual(ddata.parseLink(text, { 'clever-links': true }), result)
 })


### PR DESCRIPTION
Updates link processing logic to adds support for jsdoc style `{@linkplain}` and `{@linkcode}` tags as well as `DmdOptions['clever-links']` and `DmdOptions['monospace-links']` options per jsdoc specification. Also updates tests and function documentation.

See also [jsdoc-to-markdown pull request #302](https://github.com/jsdoc2md/jsdoc-to-markdown/pull/302).

Closes #85 