### PR TITLE
Add group globals by helper

### DIFF
--- a/helpers/helpers.js
+++ b/helpers/helpers.js
@@ -17,6 +17,7 @@ exports.tableHeadHtml = tableHeadHtml
 exports.tableRow = tableRow
 exports.deprecated = deprecated
 exports.groupBy = groupBy
+exports.groupGlobalsBy = groupGlobalsBy
 exports._groupBy = _groupBy
 exports._addGroup = _addGroup
 exports.add = add
@@ -40,16 +41,18 @@ function escape (input) {
 }
 
 /**
-replaces {@link} tags with markdown links in the suppied input text
+replaces {@link}, {@linkplain}, and {@linkcode} tags with markdown links in the supplied input text
 */
 function inlineLinks (text, options) {
   if (text) {
-    const links = ddata.parseLink(text)
+    const dmdOptions = options.data.root.options
+    const links = ddata.parseLink(text, dmdOptions)
     links.forEach(function (link) {
+      const captionFmt = link.format === 'code' ? '`' : ''
       const linked = ddata._link(link.url, options)
       if (link.caption === link.url) link.caption = linked.name
       if (linked.url) link.url = linked.url
-      text = text.replace(link.original, '[' + link.caption + '](' + link.url + ')')
+      text = text.replace(link.original, '[' + captionFmt + link.caption + captionFmt + '](' + link.url + ')')
     })
   }
   return text
@@ -168,6 +171,12 @@ function deprecated (options) {
 function groupBy (groupByFields, options) {
   groupByFields = arrayify(groupByFields)
   return handlebars.helpers.each(_groupChildren.call(this, groupByFields, options), options)
+}
+
+function groupGlobalsBy(groupByFields, options) {
+  groupByFields = arrayify(groupByFields)
+  return handlebars.helpers.each(_groupBy(ddata._globals(options), groupByFields), options)
+  // return handlebars.helpers.each(_groupBy(ddata._globals.call(this, options), groupByFields), options)
 }
 
 function _addGroup (identifiers, groupByFields) {

--- a/helpers/helpers.js
+++ b/helpers/helpers.js
@@ -173,7 +173,7 @@ function groupBy (groupByFields, options) {
   return handlebars.helpers.each(_groupChildren.call(this, groupByFields, options), options)
 }
 
-function groupGlobalsBy(groupByFields, options) {
+function groupGlobalsBy (groupByFields, options) {
   groupByFields = arrayify(groupByFields)
   return handlebars.helpers.each(_groupBy(ddata._globals(options), groupByFields), options)
 }

--- a/helpers/helpers.js
+++ b/helpers/helpers.js
@@ -176,7 +176,6 @@ function groupBy (groupByFields, options) {
 function groupGlobalsBy(groupByFields, options) {
   groupByFields = arrayify(groupByFields)
   return handlebars.helpers.each(_groupBy(ddata._globals(options), groupByFields), options)
-  // return handlebars.helpers.each(_groupBy(ddata._globals.call(this, options), groupByFields), options)
 }
 
 function _addGroup (identifiers, groupByFields) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
       },
       "devDependencies": {
         "dmd-plugin-example": "^0.1.0",
+        "mock-require": "^3.0.3",
         "test-runner": "^0.10.1"
       },
       "engines": {
@@ -468,6 +469,12 @@
         "node": ">=14"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+      "dev": true
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -596,11 +603,36 @@
       "integrity": "sha512-xOE9xbICroUDmG1ye2h4bZ8WBie9EGmACaco8K8cx6RlkJJrxGIqjGqztAI+NMhexXBcdGbSEzI6N3EJPevxZw==",
       "license": "MIT"
     },
+    "node_modules/mock-require": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/mock-require/-/mock-require-3.0.3.tgz",
+      "integrity": "sha512-lLzfLHcyc10MKQnNUCv7dMcoY/2Qxd6wJfbqCcVk3LDb8An4hF6ohk5AztrvgKhJCqj36uyzi/p5se+tvyD+Wg==",
+      "dev": true,
+      "dependencies": {
+        "get-caller-file": "^1.0.2",
+        "normalize-path": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=4.3.0"
+      }
+    },
     "node_modules/neo-async": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==",
+      "dev": true,
+      "dependencies": {
+        "remove-trailing-separator": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/object-get": {
       "version": "2.1.1",
@@ -706,6 +738,12 @@
       "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
       "integrity": "sha512-ofhi8kjIje6npGozTip9Fr8iecmYfEbS06i0JnIg+rh51KakryWF4+jX8lLKZVhy6N+ID45WYSFCxPOdTWCzNg==",
       "license": "MIT"
+    },
+    "node_modules/remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==",
+      "dev": true
     },
     "node_modules/source-map": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "partials"
   ],
   "scripts": {
-    "test": "test-runner test/*.js test/ddata/*.js"
+    "test": "test-runner test/*.js test/ddata/*.js test/helpers/*.js"
   },
   "dependencies": {
     "array-back": "^6.2.2",
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "dmd-plugin-example": "^0.1.0",
+    "mock-require": "^3.0.3",
     "test-runner": "^0.10.1"
   },
   "standard": {

--- a/test/helpers/group-globals-by.js
+++ b/test/helpers/group-globals-by.js
@@ -1,0 +1,48 @@
+const Tom = require('test-runner').Tom
+console.error('mocking...')
+const mock = require('mock-require')
+mock('handlebars', {
+  helpers: {
+    each: function (arg) { return arg }
+  }
+})
+
+const helpers = mock.reRequire('../../helpers/helpers')
+const DmdOptions = require('../../lib/dmd-options')
+const assert = require('assert').strict
+
+const tom = module.exports = new Tom('groupGlobalsBy')
+
+function makeOptions (data) {
+  return { 
+    data: { root: data },
+    hash: {},
+    inverse: function() {},
+    fn: function() {}
+  }
+}
+
+tom.test('sorts globals according to sort fields', function () {
+  const options = makeOptions([
+    { id: '1', category: 'foo', scope: 'global' },
+    { id: '2', category: 'foo', scope: 'global' },
+    { id: '3', category: 'bar', scope: 'global' },
+    { id: '4', category: 'bar', scope: 'global' },
+    { id: '5', scope: 'global' },
+    { id: 'not global' }
+  ])
+  const dmdOptions = new DmdOptions(options)
+  const groupByFields = dmdOptions['group-by']
+  const result = helpers.groupGlobalsBy(groupByFields, options)
+  assert.deepEqual(result, [
+    { _title: 'foo', level: 0 },
+    { id: '1', category: 'foo', scope: 'global', level: 1 },
+    { id: '2', category: 'foo', scope: 'global', level: 1 },
+    { _title: 'bar', level: 0 },
+    { id: '3', category: 'bar', scope: 'global', level: 1 },
+    { id: '4', category: 'bar', scope: 'global', level: 1 },
+    { id: '5', level: 0, scope: 'global' }
+  ])
+})
+
+mock.stopAll()


### PR DESCRIPTION
Adds a `groupGlobalsBy(groupFields, options)` helper function. See #87 for use case/purpose. Also implemented a test, which necessitated (I believe) adding 'mock-require' as a dev dependency.

Closes #87 