### PR TITLE
Remove dependency on common-sequence

### DIFF
--- a/helpers/helpers.js
+++ b/helpers/helpers.js
@@ -2,7 +2,6 @@ const ddata = require('./ddata')
 const arrayify = require('array-back')
 const handlebars = require('handlebars')
 const util = require('util')
-const commonSequence = require('common-sequence')
 
 /**
 A library of helpers used exclusively by dmd.. dmd also registers helpers from ddata.
@@ -168,6 +167,15 @@ function _groupChildren (groupByFields, options) {
   return _groupBy(children, groupByFields)
 }
 
+function *commonSequence(a, b) {
+  const bSet = b.values()
+  for (const aValue of a) {
+    const { done, value: bValue } = bSet.next()
+    if (done || aValue !== bValue) break
+    yield aValue
+  }
+}
+
 /**
 takes the children of this, groups them, inserts group headings..
 */
@@ -192,7 +200,7 @@ function _groupBy (identifiers, groupByFields) {
   let level = 0
   identifiers.forEach(function (identifier, index) {
     if (!deepEqual(identifier._group, prevGroup)) {
-      const common = commonSequence(identifier._group, prevGroup)
+      const common = Array.from(commonSequence(identifier._group, prevGroup))
       level = common.length
       identifier._group.forEach(function (group, i) {
         if (group !== common[i] && group !== null) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "array-back": "^6.2.2",
         "cache-point": "^3.0.0",
-        "common-sequence": "^3.0.0",
         "file-set": "^5.2.2",
         "handlebars": "^4.7.8",
         "marked": "^4.3.0",
@@ -106,15 +105,6 @@
         "@75lb/nature": {
           "optional": true
         }
-      }
-    },
-    "node_modules/common-sequence": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/common-sequence/-/common-sequence-3.0.0.tgz",
-      "integrity": "sha512-g/CgSYk93y+a1IKm50tKl7kaT/OjjTYVQlEbUlt/49ZLV1mcKpUU7iyDiqTAeLdb4QDtQfq3ako8y8v//fzrWQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.17"
       }
     },
     "node_modules/dmd-plugin-example": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   "dependencies": {
     "array-back": "^6.2.2",
     "cache-point": "^3.0.0",
-    "common-sequence": "^3.0.0",
     "file-set": "^5.2.2",
     "handlebars": "^4.7.8",
     "marked": "^4.3.0",


### PR DESCRIPTION
There is little need to use common-sequence as a dependency since the implementation is very small. With iteration over for loops the implementation is even smaller.

This change adds a `commonSequence` function that does the same thing the dependency did and removes the need to bring in even more 3rd party code into this repo.